### PR TITLE
[Podspec] Remove resource_bundles declaration

### DIFF
--- a/RxRealm.podspec
+++ b/RxRealm.podspec
@@ -21,10 +21,6 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Pod/Classes/*.swift'
 
-  s.resource_bundles = {
-    'RxRealm' => ['RxRealm/Assets/*.png']
-  }
-
   s.frameworks = 'Foundation'
   s.dependency 'RealmSwift'
   s.dependency 'RxSwift'


### PR DESCRIPTION
As there are no actual resources.
That might fix the linter error with the podspec.
