### PR TITLE
Fixes changesetArrayFrom

### DIFF
--- a/Pod/Classes/RxRealm.swift
+++ b/Pod/Classes/RxRealm.swift
@@ -153,8 +153,9 @@ public extension ObservableType where E: NotificationEmitter {
 
      - returns: `Observable<(Array<Self.Generator.Element>, RealmChangeset?)>`
      */
-    public static func changesetArrayFrom(_ collection: E, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance) -> Observable<(E, RealmChangeset?)> {
+    public static func changesetArrayFrom(_ collection: E, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance) -> Observable<(Array<E.ElementType>, RealmChangeset?)> {
         return Observable.changesetFrom(collection, scheduler: scheduler)
+					.map { ($0.toArray(), $1) }
     }
 }
 


### PR DESCRIPTION
The current implementation just returns the result of `Observable.changesetFrom`.
This patch fixes the returned observable to match the described intent of this method.
