### PR TITLE
Mt single object fix

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,13 +6,13 @@ target 'RxRealm_Example' do
   pod 'RxRealm', :path => '../'
   pod 'RxSwift',    '~> 3.0.0'
   pod 'RxCocoa',    '~> 3.0.0'
-  pod 'RealmSwift', '~> 2.0'
+  pod 'RealmSwift', '~> 2.1'
 end
 
 target 'RxRealm_Tests' do
   platform :ios, '8.0'
   pod 'RxTest',    '~> 3.0.0'
-  pod 'RealmSwift', '~> 2.0'
+  pod 'RealmSwift', '~> 2.1'
   pod 'RxRealm', :path => '../'
 end
 

--- a/Example/RxRealm.xcodeproj/project.pbxproj
+++ b/Example/RxRealm.xcodeproj/project.pbxproj
@@ -229,10 +229,12 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						DevelopmentTeam = 9MF8G8D9Y5;
 						LastSwiftMigration = 0800;
 					};
 					9CEB7A461CC834340077C44D = {
 						CreatedOnToolsVersion = 7.3;
+						DevelopmentTeam = 9MF8G8D9Y5;
 						LastSwiftMigration = 0800;
 					};
 				};
@@ -517,6 +519,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = 9MF8G8D9Y5;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$PODS_CONFIGURATION_BUILD_DIR/Realm\"",
@@ -541,6 +544,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = 9MF8G8D9Y5;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$PODS_CONFIGURATION_BUILD_DIR/Realm\"",
@@ -566,6 +570,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 9MF8G8D9Y5;
 				INFOPLIST_FILE = RxRealm_Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -581,6 +586,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ANALYZER_NONNULL = YES;
+				DEVELOPMENT_TEAM = 9MF8G8D9Y5;
 				INFOPLIST_FILE = RxRealm_Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Pod/Classes/RxRealm.swift
+++ b/Pod/Classes/RxRealm.swift
@@ -334,20 +334,24 @@ extension Reactive where Base: Realm {
 
 //MARK: Realm Object type extensions
 
-public extension ObservableType where E: Object {
+public extension Observable where Element: Object {
 
-    public static func from(_ object: E) -> Observable<E> {
+    // until there is a built-in solution from Realm to observe a single object
+    // this handy method observes a single object by its primary key
+
+    public static func from(_ object: Element) -> Observable<Element> {
 
         guard let realm = object.realm else {
-            return Observable<E>.empty()
+            return Observable<Element>.empty()
         }
-        guard let primaryKeyName = type(of: object).primaryKey(),
+
+        guard let primaryKeyName = Element.primaryKey(),
             let primaryKey = object.value(forKey: primaryKeyName) else {
             fatalError("At present you can't observe objects that don't have primary key.")
         }
 
-        return Observable<E>.create {observer in
-            let objectQuery = realm.objects(type(of: object))
+        return Observable<Element>.create {observer in
+            let objectQuery = realm.objects(Element)
                 .filter("%K == %@", primaryKeyName, primaryKey)
 
             let token = objectQuery.addNotificationBlock {changes in


### PR DESCRIPTION
* fixes crash on device when using the built-in `type(of:)` function (weird that standard lib crashes on device while works on sim, eh?)

* fixes the tests to run with latest version of Realm