### PR TITLE
Mt 3.1 fix

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,12 +6,12 @@ target 'RxRealm_Example' do
   pod 'RxRealm', :path => '../'
   pod 'RxSwift',    '~> 3.1'
   pod 'RxCocoa',    '~> 3.1'
-  pod 'RealmSwift', '~> 2.1'
+  pod 'RealmSwift', '~> 2.2'
 end
 
 target 'RxRealm_Tests' do
   platform :ios, '8.0'
   pod 'RxTest',    '~> 3.1'
-  pod 'RealmSwift', '~> 2.1'
+  pod 'RealmSwift', '~> 2.2'
   pod 'RxRealm', :path => '../'
 end

--- a/Example/RxRealm/ViewController.swift
+++ b/Example/RxRealm/ViewController.swift
@@ -15,7 +15,7 @@ class Lap: Object {
 class TickCounter: Object {
     dynamic var id = UUID().uuidString
     dynamic var ticks: Int = 0
-    override static func primaryKey() -> String? {return "id"}
+    override static func primaryKey() -> String? { return "id" }
 }
 
 //view controller
@@ -46,7 +46,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        laps = realm.objects(Lap.self).sorted(byProperty: "time", ascending: false)
+        laps = realm.objects(Lap.self).sorted(byKeyPath: "time", ascending: false)
 
         /*
          Observable<Results<Lap>> - wrap Results as observable
@@ -61,7 +61,7 @@ class ViewController: UIViewController {
         /*
          Observable<Results<Lap>> - reacting to change sets
          */
-        Observable.changesetFrom(laps)
+        Observable.changeset(from: laps)
             .subscribe(onNext: {[unowned self] results, changes in
                 if let changes = changes {
                     self.tableView.applyChangeset(changes)
@@ -93,8 +93,8 @@ class ViewController: UIViewController {
         /*
          Observing a single object
          */
-        Observable.from(ticker)
-            .map{ (ticker) -> String in
+        Observable.from(object: ticker)
+            .map { ticker -> String in
                 return "\(ticker.ticks) ticks"
             }
             .bindTo(footer.rx.text)

--- a/Example/RxRealm/ViewController.swift
+++ b/Example/RxRealm/ViewController.swift
@@ -135,9 +135,9 @@ extension ViewController: UITableViewDelegate {
 extension UITableView {
     func applyChangeset(_ changes: RealmChangeset) {
         beginUpdates()
+        deleteRows(at: changes.deleted.map { IndexPath(row: $0, section: 0) }, with: .automatic)
         insertRows(at: changes.inserted.map { IndexPath(row: $0, section: 0) }, with: .automatic)
         reloadRows(at: changes.updated.map { IndexPath(row: $0, section: 0) }, with: .automatic)
-        deleteRows(at: changes.deleted.map { IndexPath(row: $0, section: 0) }, with: .automatic)
         endUpdates()
     }
 }

--- a/Example/RxRealm/ViewController.swift
+++ b/Example/RxRealm/ViewController.swift
@@ -21,8 +21,7 @@ class TickCounter: Object {
 //view controller
 class ViewController: UIViewController {
     let bag = DisposeBag()
-    let realm = try! Realm()
-    
+
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var tickItemButton: UIBarButtonItem!
     @IBOutlet weak var addTwoItemsButton: UIBarButtonItem!
@@ -36,9 +35,10 @@ class ViewController: UIViewController {
     }()
 
     lazy var ticker: TickCounter = {
+        let realm = try! Realm()
         let ticker = TickCounter()
-        try! self.realm.write {
-            self.realm.add(ticker)
+        try! realm.write {
+            realm.add(ticker)
         }
         return ticker
     }()
@@ -46,12 +46,13 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        let realm = try! Realm()
         laps = realm.objects(Lap.self).sorted(byKeyPath: "time", ascending: false)
 
         /*
          Observable<Results<Lap>> - wrap Results as observable
          */
-        Observable.from(laps)
+        Observable.collection(from: laps)
             .map {results in "laps: \(results.count)"}
             .subscribe { event in
                 self.title = event.element
@@ -84,7 +85,7 @@ class ViewController: UIViewController {
          */
         tickItemButton.rx.tap
             .subscribe(onNext: {[unowned self] value in
-                try! self.realm.write {
+                try! realm.write {
                     self.ticker.ticks += 1
                 }
             })

--- a/Example/RxRealm_Tests/RxRealmLinkingObjectsTests.swift
+++ b/Example/RxRealm_Tests/RxRealmLinkingObjectsTests.swift
@@ -42,7 +42,7 @@ class RxRealmLinkingObjectsTests: XCTestCase {
             realm.add(message)
         }
         
-        let users$ = Observable.from(message.mentions).shareReplay(1)
+        let users$ = Observable.collection(from: message.mentions).shareReplay(1)
         users$.scan(0, accumulator: {acc, _ in return acc+1})
             .filter { $0 == 3 }.map {_ in ()}.subscribe(onNext: expectation1.fulfill).addDisposableTo(bag)
         users$
@@ -89,7 +89,7 @@ class RxRealmLinkingObjectsTests: XCTestCase {
             realm.add(message)
         }
         
-        let users$ = Observable.changesetFrom(message.mentions).shareReplay(1)
+        let users$ = Observable.changeset(from: message.mentions).shareReplay(1)
         users$.scan(0, accumulator: {acc, _ in return acc+1})
             .filter { $0 == 3 }.map {_ in ()}.subscribe(onNext: expectation1.fulfill).addDisposableTo(bag)
         users$

--- a/Example/RxRealm_Tests/RxRealmListTests.swift
+++ b/Example/RxRealm_Tests/RxRealmListTests.swift
@@ -42,7 +42,7 @@ class RxRealmListTests: XCTestCase {
             realm.add(message)
         }
         
-        let users$ = Observable.from(message.recipients).shareReplay(1)
+        let users$ = Observable.collection(from: message.recipients).shareReplay(1)
         users$.scan(0, accumulator: {acc, _ in return acc+1})
             .filter { $0 == 3 }.map {_ in ()}.subscribe(onNext: expectation1.fulfill).addDisposableTo(bag)
         users$
@@ -71,7 +71,7 @@ class RxRealmListTests: XCTestCase {
         }
     }
     
-    func testLustTypeChangeset() {
+    func testListTypeChangeset() {
         let expectation1 = expectation(description: "List<User> first")
         
         let realm = realmInMemory(#function)
@@ -86,7 +86,7 @@ class RxRealmListTests: XCTestCase {
             realm.add(message)
         }
         
-        let users$ = Observable.changesetFrom(message.recipients).shareReplay(1)
+        let users$ = Observable.changeset(from: message.recipients).shareReplay(1)
         users$.scan(0, accumulator: {acc, _ in return acc+1})
             .filter { $0 == 3 }.map {_ in ()}.subscribe(onNext: expectation1.fulfill).addDisposableTo(bag)
         users$

--- a/Example/RxRealm_Tests/RxRealmRealmTests.swift
+++ b/Example/RxRealm_Tests/RxRealmRealmTests.swift
@@ -30,7 +30,7 @@ class RxRealmRealmTests: XCTestCase {
         typealias loggedNotification = (Realm, Realm.Notification)
         let observer = scheduler.createObserver(loggedNotification.self)
         
-        let realm$ = Observable<(Realm, Realm.Notification)>.from(realm).shareReplay(1)
+        let realm$ = Observable<(Realm, Realm.Notification)>.from(realm: realm).shareReplay(1)
         realm$.scan(0, accumulator: {acc, _ in return acc+1})
             .filter { $0 == 2 }.map {_ in ()}.subscribe(onNext: expectation1.fulfill).addDisposableTo(bag)
         realm$
@@ -71,7 +71,7 @@ class RxRealmRealmTests: XCTestCase {
         typealias loggedNotification = (Realm, Realm.Notification)
         let observer = scheduler.createObserver(loggedNotification.self)
         
-        let realm$ = Observable<(Realm, Realm.Notification)>.from(realm).shareReplay(1)
+        let realm$ = Observable<(Realm, Realm.Notification)>.from(realm: realm).shareReplay(1)
         realm$.scan(0, accumulator: {acc, _ in return acc+1})
             .filter { $0 == 1 }.map {_ in ()}.subscribe(onNext: expectation1.fulfill).addDisposableTo(bag)
         realm$

--- a/Example/RxRealm_Tests/RxRealmTests.swift
+++ b/Example/RxRealm_Tests/RxRealmTests.swift
@@ -50,7 +50,7 @@ class RxRealm_Tests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
         let observer = scheduler.createObserver(Results<Message>.self)
         
-        let messages$ = Observable.from(realm.objects(Message.self)).shareReplay(1)
+        let messages$ = Observable.collection(from: realm.objects(Message.self)).shareReplay(1)
         messages$.subscribe(onNext: {
             if $0.count == 2 {
                 expectation1.fulfill()
@@ -86,7 +86,7 @@ class RxRealm_Tests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
         let observer = scheduler.createObserver(Array<Message>.self)
 
-        let messages$ = Observable.arrayFrom(realm.objects(Message.self)).shareReplay(1)
+        let messages$ = Observable.array(from: realm.objects(Message.self)).shareReplay(1)
         messages$.subscribe(onNext: {
             if $0.count == 2 {
                 expectation1.fulfill()
@@ -124,7 +124,7 @@ class RxRealm_Tests: XCTestCase {
         //initial data
         addMessage(realm, text: "first(Changeset)")
 
-        let messages$ = Observable.changesetFrom(realm.objects(Message.self)).shareReplay(1)
+        let messages$ = Observable.changeset(from: realm.objects(Message.self)).shareReplay(1)
         messages$.scan(0) { count, _ in
             return count+1
         }
@@ -185,7 +185,7 @@ class RxRealm_Tests: XCTestCase {
         //initial data
         addMessage(realm, text: "first(ArrayChangeset)")
         
-        let messages$ = Observable.changesetFrom(realm.objects(Message.self)).shareReplay(1)
+        let messages$ = Observable.changeset(from: realm.objects(Message.self)).shareReplay(1)
         messages$.scan(0) { count, _ in
             return count+1
             }

--- a/Example/RxRealm_Tests/RxRealmWriteSinks.swift
+++ b/Example/RxRealm_Tests/RxRealmWriteSinks.swift
@@ -39,7 +39,7 @@ class RxRealmWriteSinks: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
         let observer = scheduler.createObserver(Array<Message>.self)
         let observable = scheduler.createHotObservable(events).asObservable()
-        let messages$ = Observable.arrayFrom(realm.objects(Message.self)).shareReplay(1)
+        let messages$ = Observable.array(from: realm.objects(Message.self)).shareReplay(1)
 
         messages$.subscribe(observer)
             .addDisposableTo(bag)
@@ -79,7 +79,7 @@ class RxRealmWriteSinks: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
         let observer = scheduler.createObserver(Array<Message>.self)
         let observable = scheduler.createHotObservable(events).asObservable()
-        let messages$ = Observable.arrayFrom(realm.objects(Message.self)).shareReplay(1)
+        let messages$ = Observable.array(from: realm.objects(Message.self)).shareReplay(1)
         
         observable.subscribe(rx_add)
             .addDisposableTo(bag)
@@ -117,7 +117,7 @@ class RxRealmWriteSinks: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
         let observer = scheduler.createObserver(Array<UniqueObject>.self)
         let observable = scheduler.createHotObservable(events).asObservable()
-        let messages$ = Observable.arrayFrom(realm.objects(UniqueObject.self)).shareReplay(1)
+        let messages$ = Observable.array(from: realm.objects(UniqueObject.self)).shareReplay(1)
         
         observable.subscribe(rx_add)
             .addDisposableTo(bag)
@@ -153,7 +153,7 @@ class RxRealmWriteSinks: XCTestCase {
         let realm = realmInMemory(#function)
         let element = Message("1")
         let scheduler = TestScheduler(initialClock: 0)
-        let messages$ = Observable.arrayFrom(realm.objects(Message.self)).shareReplay(1)
+        let messages$ = Observable.array(from: realm.objects(Message.self)).shareReplay(1)
         let rx_delete: AnyObserver<Message> = Realm.rx.delete()
         
         try! realm.write {
@@ -197,7 +197,7 @@ class RxRealmWriteSinks: XCTestCase {
         let realm = realmInMemory(#function)
         let elements = [Message("1"), Message("1")]
         let scheduler = TestScheduler(initialClock: 0)
-        let messages$ = Observable.arrayFrom(realm.objects(Message.self)).shareReplay(1)
+        let messages$ = Observable.array(from: realm.objects(Message.self)).shareReplay(1)
         let rx_delete: AnyObserver<[Message]> = Realm.rx.delete()
         
         try! realm.write {
@@ -248,7 +248,7 @@ class RxRealmWriteSinks: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
         let observer = scheduler.createObserver(Results<Message>.self)
         
-        let messages$ = Observable.from(realm.objects(Message.self)).shareReplay(1)
+        let messages$ = Observable.collection(from: realm.objects(Message.self)).shareReplay(1)
         
         messages$
             .subscribe(observer).addDisposableTo(bag)
@@ -309,7 +309,7 @@ class RxRealmWriteSinks: XCTestCase {
             XCTAssertNil(error)
             let finalResult = observer.events.last!.value.element!
             XCTAssertTrue(finalResult.count == 8, "The final amount of objects in realm are not correct")
-            XCTAssertTrue((try! Realm(configuration: conf)).objects(Message.self).sorted(byProperty: "text")
+            XCTAssertTrue((try! Realm(configuration: conf)).objects(Message.self).sorted(byKeyPath: "text")
                 .reduce("", { acc, el in acc + el.text
             }) == "12345678" /*😈*/, "The final list of objects is not the one expected")
         })

--- a/RxRealm.podspec
+++ b/RxRealm.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/*.swift'
 
   s.frameworks = 'Foundation'
-  s.dependency 'RealmSwift', '~> 2.1'
+  s.dependency 'RealmSwift', '~> 2.2'
   s.dependency 'RxSwift',    '~> 3.1'
 
 end


### PR DESCRIPTION
	* renamed all methods to avoid RxSwift 3.1 clash  …
* added deprecated availability to all deprecated methods
* did a pass on coding style
* added updated docs to all changed methods
* removed scheduler parameters, which weren't used
* added synchronousStart parameter to toggle sync/async first emit
* added new tests for sync/async emits