### PR TITLE
fix deprecated method name tag

### DIFF
--- a/Pod/Classes/RxRealm.swift
+++ b/Pod/Classes/RxRealm.swift
@@ -415,7 +415,7 @@ extension Reactive where Base: Realm {
 
 public extension Observable where Element: Object {
 
-    @available(*, deprecated, renamed: "from(realm:)")
+    @available(*, deprecated, renamed: "from(object:)")
     public static func from(_ object: Element) -> Observable<Element> {
         return from(object: object)
     }


### PR DESCRIPTION
it caused the editor to suggest incorrect replacement method for the deprecated `Observable.from(_ object: Element)`