### PR TITLE
Object notification

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,12 +6,12 @@ target 'RxRealm_Example' do
   pod 'RxRealm', :path => '../'
   pod 'RxSwift',    '~> 3.1'
   pod 'RxCocoa',    '~> 3.1'
-  pod 'RealmSwift', '~> 2.2'
+  pod 'RealmSwift', '~> 2.4'
 end
 
 target 'RxRealm_Tests' do
   platform :ios, '8.0'
   pod 'RxTest',    '~> 3.1'
-  pod 'RealmSwift', '~> 2.2'
+  pod 'RealmSwift', '~> 2.4'
   pod 'RxRealm', :path => '../'
 end

--- a/Example/RxRealm_Tests/RxRealmObjectTests.swift
+++ b/Example/RxRealm_Tests/RxRealmObjectTests.swift
@@ -85,7 +85,7 @@ class RxRealmObjectTests: XCTestCase {
         }
     }
 
-    func testObjectEmitsSynchronously() {
+    func testObjectEmitsInitialChange() {
         let realm = realmInMemory(#function)
         let bag = DisposeBag()
 
@@ -100,7 +100,7 @@ class RxRealmObjectTests: XCTestCase {
         }
 
         //test sync emit
-        Observable<UniqueObject>.from(object: obj, synchronousStart: true)
+        Observable<UniqueObject>.from(object: obj, emitInitialValue: true)
             .subscribe(observer)
             .addDisposableTo(bag)
 
@@ -125,7 +125,7 @@ class RxRealmObjectTests: XCTestCase {
         }
 
         //test async emit
-        let object$ = Observable<UniqueObject>.from(object: obj, synchronousStart: false)
+        let object$ = Observable<UniqueObject>.from(object: obj, emitInitialValue: false)
             .share()
 
         object$
@@ -139,6 +139,11 @@ class RxRealmObjectTests: XCTestCase {
             .addDisposableTo(bag)
 
         XCTAssertEqual(observer.events.count, 0)
+        
+        //write change
+        try! realm.write {
+            obj.name = "test"
+        }
 
         waitForExpectations(timeout: 5) {error in
             XCTAssertTrue(error == nil)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Observable.arrayWithChangeset(from: laps)
 
 ## Observing a single object
 
-There's a separate API to make it easier to observe a single object (it creates `Results` behind the scenes):
+There's a separate API to make it easier to observe a single object:
 
 ```swift
 Observable.from(object: ticker)
@@ -109,7 +109,7 @@ Observable.from(object: ticker)
     .bindTo(footer.rx.text)
 ```
 
-This API uses the primary key of the object to query the database for it and observe for change notifications. Observing objects without a primary key does not work.
+This API uses the [Realm object notifications](https://realm.io/news/realm-objc-swift-2.4/) under the hood to listen for changes.
 
 ## Write transactions
 


### PR DESCRIPTION
Hey there,

since Realm 2.4 added [object notifications](realm 2.4 object notifications), I refactored the old primary-key-based approach to use these.

Please note:
- that it requires at least Realm 2.4 for the notifications to work
- that it breaks (on purpose) the old signature since there is no notion of synchronous/asynchronous emission anymore. There is now an `emitInitialValue` to force the returned observable to emit its initial value

Regards