### PR TITLE
Remove onCompleted methods on dispose

### DIFF
--- a/Pod/Classes/RxRealm.swift
+++ b/Pod/Classes/RxRealm.swift
@@ -139,7 +139,6 @@ public extension ObservableType where E: NotificationEmitter, E.ElementType: Obj
 
             return Disposables.create {
                 token.stop()
-                observer.onCompleted()
             }
         }
     }
@@ -201,7 +200,6 @@ public extension ObservableType where E: NotificationEmitter, E.ElementType: Obj
             }
 
             return Disposables.create {
-                observer.onCompleted()
                 token.stop()
             }
         }
@@ -261,7 +259,6 @@ public extension Observable {
             }
 
             return Disposables.create {
-                observer.onCompleted()
                 token.stop()
             }
         }


### PR DESCRIPTION
The newer RxSwift versions recently increased the enforcement level of recursive call or synchronization error. RxRealm is causing a crash because of calling `observer.onCompleted()` on dispose of the observables. This PR fixes the issue.

See https://github.com/ReactiveX/RxSwift/issues/1192 for reference.