### PR TITLE
Observable sequence should not attempt to send any further messages on explicit unsubscription.

### DIFF
--- a/Pod/Classes/RxRealm.swift
+++ b/Pod/Classes/RxRealm.swift
@@ -139,7 +139,6 @@ public extension ObservableType where E: NotificationEmitter, E.ElementType: Obj
 
             return Disposables.create {
                 token.stop()
-                observer.onCompleted()
             }
         }
     }
@@ -201,7 +200,6 @@ public extension ObservableType where E: NotificationEmitter, E.ElementType: Obj
             }
 
             return Disposables.create {
-                observer.onCompleted()
                 token.stop()
             }
         }
@@ -261,7 +259,6 @@ public extension Observable {
             }
 
             return Disposables.create {
-                observer.onCompleted()
                 token.stop()
             }
         }


### PR DESCRIPTION
Recently, I found an issue with RxRealm triggering RxSwift assertions in these (looking quite innocent) lines of code (copied from MWE playground):

```
import Realm
import RealmSwift
import RxSwift
import RxRealm
import PlaygroundSupport

PlaygroundPage.current.needsIndefiniteExecution = true

let disposeBag = DisposeBag()

class TestObject: Object {

    dynamic var value: String = ""
    
    required init() {
        super.init()
    }
    
    required init(realm: RLMRealm, schema: RLMObjectSchema) {
        super.init(realm: realm, schema: schema)
    }
    
    required init(value: Any, schema: RLMSchema) {
        super.init(value: value, schema: schema)
    }
}

let realm = try Realm()
let results = realm.objects(TestObject.self)
Observable.collection(from: results, synchronousStart: false).take(1).subscribe(onNext: {
    print($0)
}).disposed(by: disposeBag)
```

Turns out, it is due to the fact that RxRealm tries to send additional onCompleted event even after explicit disposal of subscription. Specifically, in this case, take(1) unsubscribe immediately upon receiving its first onNext event, but as disposal closure calls onCompleted immediately, RxRealm observable receives onCompleted event before it returns from onNext handler (and thats triggers RxSwift assertion).

Moreover, the implementation is not consistent - Observables created from Object type extensions do not call onCompleted in cancellation handler.

Thus, this PR:

1. unifies behavior across all methods (by removing excessive onCompleted() call)
2. fixes problems with RxSwift assertion