### PR TITLE
Update incorrect parameter name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This library is a thin wrapper around __RealmSwift__ ( [Realm Docs](https://real
 
 RxRealm can be used to create `Observable`s from objects of type `Results`, `List`, `LinkingObjects` or `AnyRealmCollection`. These types are typically used to load and observe object collections from the Realm Mobile Database.
 
-##### `Observable.collection(from:synchronizedStart:)`
+##### `Observable.collection(from:synchronousStart:)`
 Emits an event each time the collection changes:
 
 ```swift
@@ -35,9 +35,9 @@ Observable.collection(from: laps)
   })
 ```
 
-The above prints out "X laps" each time a lap is added or removed from the database. If you set `synchronizedStart` to `true` (the default value), the first element will be emitted synchronously - e.g. when you're binding UI you might not be able for an asynchronous notification to come through.
+The above prints out "X laps" each time a lap is added or removed from the database. If you set `synchronousStart` to `true` (the default value), the first element will be emitted synchronously - e.g. when you're binding UI you might not be able for an asynchronous notification to come through.
 
-##### `Observable.array(from:synchronizedStart:)`
+##### `Observable.array(from:synchronousStart:)`
 Upon each change fetches a snapshot of the Realm collection and converts it to an array value (for example if you want to use array methods on the collection):
 
 ```swift
@@ -53,7 +53,7 @@ Observable.array(from: laps)
   })
 ```
 
-##### `Observable.changeset(from:synchronizedStart:)`
+##### `Observable.changeset(from:synchronousStart:)`
 Emits every time the collection changes and provides the exact indexes that has been deleted, inserted or updated:
 
 ```swift
@@ -75,7 +75,7 @@ Observable.changeset(from: laps)
   })
 ```
 
-##### `Observable.arrayWithChangeset(from:synchronizedStart:)`
+##### `Observable.arrayWithChangeset(from:synchronousStart:)`
 Combines the result of `Observable.array(from:)` and `Observable.changeset(from:)` returning an `Observable<Array<T>, RealmChangeset?>`
 
 ```swift


### PR DESCRIPTION
`synchronizedStart` really is `synchronousStart` in the current implementation