### PR TITLE
Added SyncUser Extension

### DIFF
--- a/Pod/Classes/RxRealm.swift
+++ b/Pod/Classes/RxRealm.swift
@@ -575,5 +575,53 @@ public extension Observable where Element: Object {
         }
     }
 
-    
+}
+
+
+extension SyncUser {
+
+    /**
+     Returns an `Observable<SyncUser>` that emits the current logged in user.
+
+     - parameter credentials: A `SyncCredential` object
+     - parameter server: The `URL` to log in to
+     - returns: `Observable<SyncUser>` will emit the current `SynceUser` once logged in
+     */
+    static func logIn(with credentials: SyncCredentials, server: URL) -> Observable<SyncUser> {
+        return Observable.create({ observer in
+            self.logIn(with: credentials, server: server) { user, error in
+                if let error = error {
+                    observer.onError(error)
+                }
+                if let user = user {
+                    observer.onNext(user)
+                }
+            }
+            return Disposables.create()
+        })
+    }
+
+
+    /**
+     Returns a function from a `SyncCredentials` object to a `Observable<SyncUser>` that emits the current logged in user.
+
+     - parameter server: The `URL` to log in to
+     - returns: a function from a `SyncCredentials` object to a `Observable<SyncUser>`
+     */
+    static func logIn(to server: URL) -> (SyncCredentials) -> Observable<SyncUser> {
+        return { credentials in
+            return Observable.create({ observer in
+                self.logIn(with: credentials, server: server) { user, error in
+                    if let error = error {
+                        observer.onError(error)
+                    }
+                    if let user = user {
+                        observer.onNext(user)
+                    }
+                }
+                return Disposables.create()
+            })
+        }
+    }
+
 }


### PR DESCRIPTION
added two methods for logging into a Realm Object Server.

The first method copies `SyncUser.logIn(with credentials: SyncCredentials, server: URL, completionBlock: (SyncUser?, Error?) -> Void)`, but instead returns an `Observable<SyncUser>`

The second method pulls out the `SyncCredentials` from the method definition and returns a function `SyncCredentials -> Observable<SyncUser>`.

The second method is useful for creating the `SyncCredentials` object first, then mapping this into the method