### PR TITLE
Add support for SwiftPM based dependency managers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,34 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Realm",
+        "repositoryURL": "https://github.com/realm/realm-cocoa.git",
+        "state": {
+          "branch": null,
+          "revision": "466837115bd6c7324953e00daf3a9a681f3ee025",
+          "version": "3.17.1"
+        }
+      },
+      {
+        "package": "RealmCore",
+        "repositoryURL": "https://github.com/realm/realm-core",
+        "state": {
+          "branch": null,
+          "revision": "341ccfccbd9758171a3f2aaa78604ce60553b7ca",
+          "version": "5.23.1"
+        }
+      },
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "cce95dd704bc08cd3d69c087a05a6fc3118e2722",
+          "version": "4.5.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
             dependencies: [
                     "Realm",
                     "RealmSwift"
-                ]
-            ),
+                ],
             path: "Pod/Classes"
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -12,11 +12,11 @@ let package = Package(
     targets: [
         .target(
             name: "RxRealm",
-            path: "Pod/Classes",
             dependencies: [
-                "Realm",
-                "RealmSwift"
-            ]
-        )
+                    "Realm",
+                    "RealmSwift"
+                ]
+            ),
+            path: "Pod/Classes"
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "RxRealm",
     dependencies: [
         .package(url: "https://github.com/AccioSupport/realm-cocoa.git", .branch("master"))
-    ]
+    ],
     products: [
         .library(name: "RxRealm", targets: ["RxRealm"])
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .library(name: "RxRealm", targets: ["RxRealm"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "4.0.0")),
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.0")),
         .package(url: "https://github.com/realm/realm-cocoa.git", .upToNextMajor(from: "3.17.1"))
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "4.0.0")),
-        .package(url: "https://github.com/AccioSupport/realm-cocoa.git", .branch("master"))
+        .package(url: "https://github.com/realm/realm-cocoa.git", .revision("7c627b44f4d73aaa5e385aeb0fae7775d3ece85b"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "RxRealm",
+    products: [
+        .library(name: "RxRealm", targets: ["RxRealm"])
+    ],
+    targets: [
+        .target(
+            name: "RxRealm",
+            path: "Pod/Classes"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,11 @@ import PackageDescription
 
 let package = Package(
     name: "RxRealm",
-    dependencies: [
-        .package(url: "https://github.com/AccioSupport/realm-cocoa.git", .branch("master"))
-    ],
     products: [
         .library(name: "RxRealm", targets: ["RxRealm"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/AccioSupport/realm-cocoa.git", .branch("master"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -7,12 +7,15 @@ let package = Package(
         .library(name: "RxRealm", targets: ["RxRealm"])
     ],
     dependencies: [
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "4.0.0")),
         .package(url: "https://github.com/AccioSupport/realm-cocoa.git", .branch("master"))
     ],
     targets: [
         .target(
             name: "RxRealm",
             dependencies: [
+                    "RxSwift",
+                    "RxCocoa",
                     "Realm",
                     "RealmSwift"
                 ],

--- a/Package.swift
+++ b/Package.swift
@@ -3,13 +3,20 @@ import PackageDescription
 
 let package = Package(
     name: "RxRealm",
+    dependencies: [
+        .package(url: "https://github.com/AccioSupport/realm-cocoa.git", .branch("master"))
+    ]
     products: [
         .library(name: "RxRealm", targets: ["RxRealm"])
     ],
     targets: [
         .target(
             name: "RxRealm",
-            path: "Pod/Classes"
+            path: "Pod/Classes",
+            dependencies: [
+                "Realm",
+                "RealmSwift"
+            ]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
@@ -8,7 +8,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "4.0.0")),
-        .package(url: "https://github.com/realm/realm-cocoa.git", .revision("7c627b44f4d73aaa5e385aeb0fae7775d3ece85b"))
+        .package(url: "https://github.com/realm/realm-cocoa.git", .upToNextMajor(from: "3.17.1"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. I tested using it with [Accio](https://github.com/JamitLabs/Accio) pointing out to my fork of the repo.

Currently, there's an open pull request [(#6127)](https://github.com/realm/realm-cocoa/pull/6127) on realm repo to add support for SPM based dependency managers too.

if/once it is integrated into the main repository, the dependency to RealmSwift will be changed to 

```swift
.package(url: "https://github.com/realm/realm-cocoa.git", .upToNextMajor(from: "3.15.0"))
```
to install it using Accio, just add the dependency on your `Package.swift`

### [dependencies]
```swift 
.package(url: "https://github.com/RxSwiftCommunity/RxRealm.git", .upToNextMajor(from: "1.0.0"))
```

### [targets]
```swift
.target(
    name: "AppName",
    dependencies: [
        ... [Assuming you already have Realm and RxSwift here] ...,
        "RxRealm"
    ]
)
```