### PR TITLE
update realm swift pod spect

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -5,7 +5,7 @@ use_frameworks!
 def common
   pod 'RxSwift', '~> 5.0'
   pod 'RxCocoa', '~> 5.0'
-  pod 'RealmSwift', '~> 5.0'
+  pod 'RealmSwift', '=10.1.0'
 end
 
 target 'RxRealm_Example' do

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,23 +1,23 @@
 PODS:
-  - Realm (5.0.0):
-    - Realm/Headers (= 5.0.0)
-  - Realm/Headers (5.0.0)
-  - RealmSwift (5.0.0):
-    - Realm (= 5.0.0)
+  - Realm (10.1.0):
+    - Realm/Headers (= 10.1.0)
+  - Realm/Headers (10.1.0)
+  - RealmSwift (10.1.0):
+    - Realm (= 10.1.0)
   - RxBlocking (5.0.1):
     - RxSwift (~> 5)
   - RxCocoa (5.0.1):
     - RxRelay (~> 5)
     - RxSwift (~> 5)
-  - RxRealm (2.0.0):
-    - RealmSwift (~> 5.0)
+  - RxRealm (3.1.0):
+    - RealmSwift (= 10.1.0)
     - RxSwift (~> 5.0)
   - RxRelay (5.0.1):
     - RxSwift (~> 5)
   - RxSwift (5.0.1)
 
 DEPENDENCIES:
-  - RealmSwift (~> 5.0)
+  - RealmSwift (= 10.1.0)
   - RxBlocking (~> 5.0)
   - RxCocoa (~> 5.0)
   - RxRealm (from `../`)
@@ -37,14 +37,14 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Realm: 76066d333de26f97e9caedaa85ee3ff4a62ca265
-  RealmSwift: c1bdff09b422569dc6881410d9ccf712bcdb79b0
+  Realm: 100df88a0faf5328f48477427e4b3e1a1598bae3
+  RealmSwift: 725d1c10df64964b04aaa0058c19ce0f4b4c3f5a
   RxBlocking: c5e090f42d046df8b0e7752742510f349963710f
   RxCocoa: e741b9749968e8a143e2b787f1dfbff2b63d0a5c
-  RxRealm: e3dedde1087480209362d91fe51d4ca5b24a8eed
+  RxRealm: 6cc75ddc7d564e091c04c0245ccd50d185d19db0
   RxRelay: 89d54507f4fd4d969e6ec1d4bd7f3673640b4640
   RxSwift: e2dc62b366a3adf6a0be44ba9f405efd4c94e0c4
 
-PODFILE CHECKSUM: a78ac0903554ff2c7c096d6027ef4c90f9202ec7
+PODFILE CHECKSUM: fa3b2f9f4c53fb2603dfc51255d4ea581f3c2fb7
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.10.0

--- a/RxRealm.podspec
+++ b/RxRealm.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/*.swift'
 
   s.frameworks = 'Foundation'
-  s.dependency 'RealmSwift', '~> 5.2'
+  s.dependency 'RealmSwift', '=10.1.0'
   s.dependency 'RxSwift', '~> 5.0'
 
 end


### PR DESCRIPTION
Why update Realm Swift from 5.0 to 10.1?

first it's an update, with latest code, but most important, the version 10 make it easier to connect with realm cloud (mongo atlas service)