### PR TITLE
fix deprecated method name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [5.0.3](https://github.com/wogus3602/RxRealm/branches/compare/v5.0.3%0Dv5.0.2) (2022-01-22)
+
+
+### Bug Fixes
+
+* replacing rx attribute of Realm type by standard Reactive extension. ([dabb105](https://github.com/wogus3602/RxRealm/commits/dabb105c94a6c0fdccbf99bb618b618be3f0d5c0))
+* update Realm and RxSwift to latest version ([#178](https://github.com/wogus3602/RxRealm/issues/178)) ([63d00c6](https://github.com/wogus3602/RxRealm/commits/63d00c6349b31d4e26fd5b5a5e428400b6b91356))
+
 ### [5.0.4](https://github.com/RxSwiftCommunity/RxRealm/branches/compare/v5.0.4%0Dv5.0.3) (2022-01-19)
 
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Observable.from(object: ticker)
     .map { ticker -> String in
         return "\(ticker.ticks) ticks"
     }
-    .bindTo(footer.rx.text)
+    .bind(to: footer.rx.text)
 ```
 
 This API uses the [Realm object notifications](https://realm.io/news/realm-objc-swift-2.4/) under the hood to listen for changes.
@@ -157,7 +157,7 @@ var config = Realm.Configuration()
 
 let messages = [Message("hello"), Message("world")]
 Observable.from(messages)
-  .observeOn( /* you can switch threads here */ )     
+  .observe(on: /* you can switch threads here */ )     
   .subscribe(Realm.rx.add(configuration: config, onError: {elements, error in
     if let elements = elements {
       print("Error \(error.localizedDescription) while saving objects \(String(describing: elements))")
@@ -173,7 +173,7 @@ If you want to create a Realm on a different thread manually, allowing you to ha
 let messages = [Message("hello"), Message("world")]
 
 Observable.from(messages)
-  .observeOn( /* you can switch threads here */ )
+  .observe(on: /* you can switch threads here */ )
   .subscribe(onNext: {messages in
     let realm = try! Realm()
     try! realm.write {
@@ -210,16 +210,16 @@ RxRealm does not depend on UIKit/Cocoa and it doesn't provide built-in way to bi
 
 #### a) Non-animated binding
 
-You can use the built-in RxCocoa `bindTo(_:)` method, which will automatically drive your table view from your Realm results:
+You can use the built-in RxCocoa `bind(to:)` method, which will automatically drive your table view from your Realm results:
 
 ```swift
 Observable.from( [Realm collection] )
-  .bindTo(tableView.rx.items) {tv, ip, element in
+  .bind(to: tableView.rx.items) {tv, ip, element in
     let cell = tv.dequeueReusableCell(withIdentifier: "Cell")!
     cell.textLabel?.text = element.text
     return cell
   }
-  .addDisposableTo(bag)
+  .disposed(by: bag)
 ```
 
 #### b) Animated binding with RxRealmDataSources
@@ -242,8 +242,8 @@ let laps = Observable.changeset(from: lapsList)
 
 // bind to table view
 laps
-  .bindTo(tableView.rx.realmChanges(dataSource))
-  .addDisposableTo(bag)
+  .bind(to: tableView.rx.realmChanges(dataSource))
+  .disposed(by: bag)
 ```
 
 The data source will reflect all changes via animations to the table view:

--- a/RxRealm.podspec
+++ b/RxRealm.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = "RxRealm"
   # Version to always follow latest tag, with fallback to major
-  s.version = "5.0.4"
+  s.version = "5.0.3"
   s.license = "MIT"
   s.description = <<-DESC
     This is an Rx extension that provides an easy and straight-forward way


### PR DESCRIPTION
- bindTo -> bind(to:)
- observeOn -> observe(on:)
- addDisposableTo -> disposed(by:)