### PR TITLE
Using again ReactiveCompatible extension on Realm type

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "realm/realm-cocoa" ~> 10.5
-github "ReactiveX/RxSwift" ~> 6.0
+github "ReactiveX/RxSwift" ~> 6.1

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(name: "RxRealm",
                       dependencies: [
                         // Dependencies declare other packages that this package depends on.
                         .package(url: "https://github.com/realm/realm-cocoa.git", .upToNextMajor(from: "10.5.0")),
-                        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.0.0"))
+                        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.1.0"))
                       ],
 
                       targets: [

--- a/RxRealm.podspec
+++ b/RxRealm.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
   s.frameworks = "Foundation"
   s.dependency "Realm", "~> 10.7"
   s.dependency "RealmSwift", "~> 10.7"
-  s.dependency "RxSwift", "~> 6.0"
-  s.dependency "RxCocoa", "~> 6.0"
+  s.dependency "RxSwift", "~> 6.1"
+  s.dependency "RxCocoa", "~> 6.1"
 end

--- a/Sources/RxRealm/RxRealm.swift
+++ b/Sources/RxRealm/RxRealm.swift
@@ -275,20 +275,10 @@ public extension Observable {
 }
 
 // MARK: Realm type extensions
-public extension Realm {
-  var rx: Realm.Rx { .init(self) }
 
-  struct Rx {
-    private let base: Realm
+extension Realm: ReactiveCompatible {}
 
-    init(_ base: Realm) {
-      self.base = base
-    }
-  }
-}
-
-// MARK: - Instance Reactive Extensions
-public extension Realm.Rx {
+public extension Reactive where Base == Realm {
   /**
    Returns bindable sink wich adds object sequence to the current Realm
 
@@ -388,16 +378,7 @@ public extension Realm.Rx {
   }
 }
 
-// MARK: - Static Reactive Extensions
-public extension Realm {
-  static var rx: RxStatic.Type {
-    RxStatic.self
-  }
-
-  struct RxStatic {}
-}
-
-public extension Realm.RxStatic {
+public extension Reactive where Base == Realm {
   /**
    Returns bindable sink wich adds object sequence to a Realm
 


### PR DESCRIPTION
Starting from RxSwift 6.1 version, it is – again – possible to use the somehow standard `rx` attribute of `ReactiveCompatible` protocol extension on a non-class type like `Realm`. (https://github.com/ReactiveX/RxSwift/pull/2285)

This would again allow users of RxRealm to define their custom `realm.rx.someCustomMethod()` extension methods along with RxRealm ones. Ex:

```swift
extension Reactive where Base == Realm {
    func observeOptional<R: Object>(_ type: R.Type, identifier: String) -> Observable<R?> {
        Observable
            .collection(from: base.objects(R.self).filter(NSPredicate(format: "\(R.self.primaryKey()!) == %@", identifier)))
            .map { $0.first }
    }
}
```

Defining such extension is currently not possible as the _ad hoc_ `rx` extension of RxRealm has a `base` attribute with `private` visibility, which prevents from using it in custom methods outside this pod.