### PR TITLE
Add a public Observable alias to overcome Xcode 15 bug

### DIFF
--- a/Sources/RxRealm/Observable+Alias.swift
+++ b/Sources/RxRealm/Observable+Alias.swift
@@ -1,0 +1,10 @@
+//
+//  Observable+Alias.swift
+//  RxRealm
+//
+//  Created by Gabriel Menezes de Antonio on 23/08/23.
+//
+
+import RxSwift
+
+public typealias Observable = RxSwift.Observable


### PR DESCRIPTION
Xcode 15 beta 6+ is failing builds, reported in https://github.com/apple/swift/issues/67815.

@freak4pc's Fix (https://github.com/RxSwiftCommunity/RxSwiftExt/commit/494fe20b5a6bfafb24d6a272fb90a94e1766a6cd) in [RxSwiftExt](https://github.com/RxSwiftCommunity/RxSwiftExt) repo for this issue also resolves this problem, which was reported in https://github.com/RxSwiftCommunity/RxSwiftExt/issues/272

#trivial