### PR TITLE
build: Fix building with Xcode 15.

### DIFF
--- a/Sources/RxRealm/RxRealm.swift
+++ b/Sources/RxRealm/RxRealm.swift
@@ -10,6 +10,8 @@ import Foundation
 import RealmSwift
 import RxSwift
 
+public typealias Observable<Element> = RxSwift.Observable<Element>
+
 public enum RxRealmError: Error {
   case objectDeleted
   case unknown
@@ -247,7 +249,8 @@ public extension ObservableType where Element: NotificationEmitter {
 
 public extension Observable {
   @available(*, deprecated, renamed: "from(realm:)")
-  static func from(_ realm: Realm, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance) -> Observable<(Realm, Realm.Notification)> {
+  static func from(_ realm: Realm, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance) -> Observable<(Realm, Realm.Notification)>
+    where Element == (Realm, Realm.Notification) {
     return from(realm: realm)
   }
 
@@ -265,7 +268,7 @@ public extension Observable {
    - parameter realm: A Realm instance
    - returns: `Observable<(Realm, Realm.Notification)>`, which you can subscribe to
    */
-  static func from(realm: Realm) -> Observable<(Realm, Realm.Notification)> {
+    static func from(realm: Realm) -> Observable<(Realm, Realm.Notification)> where Element == (Realm, Realm.Notification) {
     return Observable<(Realm, Realm.Notification)>.create { observer in
       let token = realm.observe { (notification: Realm.Notification, realm: Realm) in
         observer.onNext((realm, notification))


### PR DESCRIPTION
This PR fixes [building with Xcode 15](https://github.com/RxSwiftCommunity/RxRealm/issues/199) by adding the same workaround that was introduced in [RxSwiftExt](https://github.com/RxSwiftCommunity/RxSwiftExt/commit/494fe20b5a6bfafb24d6a272fb90a94e1766a6cd).