### PR TITLE
update RxRealm.podspec: Realm dependency updated to 10.44

### DIFF
--- a/RxRealm.podspec
+++ b/RxRealm.podspec
@@ -24,8 +24,8 @@ Pod::Spec.new do |s|
   s.source_files = "Sources/RxRealm/*.swift"
 
   s.frameworks = "Foundation"
-  s.dependency "Realm", "~> 10.40.1"
-  s.dependency "RealmSwift", "~> 10.40.1"
+  s.dependency "Realm", "~> 10.44"
+  s.dependency "RealmSwift", "~> 10.44"
   s.dependency "RxSwift", "~> 6.1"
   s.dependency "RxCocoa", "~> 6.1"
 end


### PR DESCRIPTION
Realm dependency updated to 10.44

Is there any reason we want to stick with 10.40.1?
