### PR TITLE
Fix `Realm` link error #trivial

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,6 @@ let package = Package(name: "RxRealm",
                         .target(name: "RxRealm",
                                 dependencies: [
                                   .product(name: "RxSwift", package: "RxSwift"),
-                                  .product(name: "Realm", package: "Realm"),
                                   .product(name: "RealmSwift", package: "Realm"),
                                   .product(name: "RxCocoa", package: "RxSwift")
                                 ],
@@ -35,7 +34,6 @@ let package = Package(name: "RxRealm",
                                       .byName(name: "RxRealm"),
                                       .product(name: "RxSwift", package: "RxSwift"),
                                       .product(name: "RxBlocking", package: "RxSwift"),
-                                      .product(name: "Realm", package: "Realm"),
                                       .product(name: "RealmSwift", package: "Realm"),
                                       .product(name: "RxCocoa", package: "RxSwift")
                                     ])


### PR DESCRIPTION
I use RxRealm via SPM. Thanks.

By the way,  When I build on an Apple Silicon Mac, I get the following error
(Xcode 15.2, MacOS 14.4.1（23E224))

> Swift package target 'Realm' is linked as a static library by 'RxRealmTests' and 'Realm', but cannot be built dynamically because there is a package product with the same name.

I noticed that there is no need to include `Realm` directly in the dependency on the RxRealm side, since `RealmSwift` is already linked to `Realm`.